### PR TITLE
updated regEx to validate days and months 

### DIFF
--- a/src/jsonclass.prg
+++ b/src/jsonclass.prg
@@ -4,7 +4,7 @@ define class JSONClass as session
 	LastErrorText 	= ""
 	lError 			= .f.
 	lShowErrors 	= .t.
-	version 		= "9.14"
+	version 		= "9.15"
 	hidden lInternal
 	hidden lTablePrompt
 	Dimension aCustomArray[1]

--- a/src/jsonutils.prg
+++ b/src/jsonutils.prg
@@ -33,16 +33,16 @@ define class jsonutils as custom
 		this.aPattern[5,2] = .t.
 		
 		&& "DD/MM/YYYY HH:MM:SS" or "DD-MM-YYYY HH:MM:SS"
-		this.aPattern[6,1] = "^(\d{2})([\/-])(\d{2})\2(\d{4}) (\d{2}):(\d{2}):(\d{2})$"
-		this.aPattern[6,2] = .t.
-		
-		&& "DD/MM/YY HH:MM:SS" or "DD-MM-YY HH:MM:SS"
-		this.aPattern[7,1] = "^(\d{2})([\/-])(\d{2})\2(\d{2}) ([0-1]\d|2[0-3]):([0-5]\d):([0-5]\d)$"
-		this.aPattern[7,2] = .t.
-		
+		this.aPattern[06,1] = "^([0-2][0-9]|(3)[0-1])[\/-](((0)[0-9])|((1)[0-2]))[\/-]\d{4} (\d{2}):(\d{2}):(\d{2})$"
+		this.aPattern[06,2] = .t.
+
 		&& "DD/MM/YY" or "DD-MM-YY"
-		this.aPattern[8,1] = "^(\d{2})([\/-])(\d{2})\2(\d{2})$"
-		this.aPattern[8,2] = .t.
+		this.aPattern[07,1] = "^([0-2][0-9]|(3)[0-1])[\/-](((0)[0-9])|((1)[0-2]))[\/-]\d{2}$" 
+		this.aPattern[07,2] = .t.
+
+		&& "DD/MM/YY HH:MM:SS" or "DD-MM-YY HH:MM:SS"
+		this.aPattern[08,1] =  "^([0-2][0-9]|(3)[0-1])[\/-](((0)[0-9])|((1)[0-2]))[\/-]\d{2} (\d{2}):(\d{2}):(\d{2})$" 
+		this.aPattern[08,2] = .t.
 		
 		_screen.oRegEx.global = .t.
 


### PR DESCRIPTION
I have updated the recently added regEx to validate the days and months, because they were not validating the days with limit of 31 and months with limit of 12

![image](https://github.com/Irwin1985/JSONFox/assets/89362488/dc84a139-d3bd-45e3-8e31-b5a16fb0e2ca)
